### PR TITLE
Fix license header

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.openmicroscopy/ome-codecs.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.openmicroscopy%22%20AND%20a%3A%22ome-codecs%22)
 [![Javadocs](http://javadoc.io/badge/org.openmicroscopy/ome-codecs.svg)](http://javadoc.io/doc/org.openmicroscopy/ome-codecs)
 
-Common I/O, date parsing, and XML processing classes for OME Java components.
-
+Image encoding and decoding routines.
 
 More information
 ----------------
@@ -20,18 +19,11 @@ Pull request testing
 We welcome pull requests from anyone, but ask that you please verify the
 following before submitting a pull request:
 
- * verify that the branch merges cleanly into ```develop```
- * verify that the branch compiles with the ```clean jars tools``` Ant targets
+ * verify that the branch merges cleanly into ```master```
  * verify that the branch compiles using Maven
  * verify that the branch does not use syntax or API specific to Java 1.8+
- * run the unit tests (```ant test```) and correct any failures
- * test at least one file in each affected format, using the ```showinf```
-   command
- * internal developers only: [run the data
-   tests](http://www.openmicroscopy.org/site/support/bio-formats/developers/commit-testing.html)
-   against directories corresponding to the affected format(s)
- * make sure that your commits contain the correct authorship information and,
-   if necessary, a signed-off-by line
+ * run the unit tests (```mvn test```) and correct any failures
+ * make sure that your commits contain the correct authorship information
  * make sure that the commit messages or pull request comment contains
    sufficient information for the reviewer(s) to understand what problem was
    fixed and how to test it

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
   - Board of Regents of the University of Wisconsin-Madison
   - Glencoe Software, Inc.
   - University of Dundee</organizationName>
-          <projectName>Common package for I/O and related utilities</projectName>
+          <projectName>Image encoding and decoding routines.</projectName>
           <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
           <canUpdateDescription>true</canUpdateDescription>
           <!-- NB: Avoid stomping on variant copyright holders. -->

--- a/src/main/java/ome/codecs/Base64Codec.java
+++ b/src/main/java/ome/codecs/Base64Codec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/BaseCodec.java
+++ b/src/main/java/ome/codecs/BaseCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/BitBuffer.java
+++ b/src/main/java/ome/codecs/BitBuffer.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/BitWriter.java
+++ b/src/main/java/ome/codecs/BitWriter.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/ByteVector.java
+++ b/src/main/java/ome/codecs/ByteVector.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/Codec.java
+++ b/src/main/java/ome/codecs/Codec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * Top-level reader and writer APIs
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/CodecException.java
+++ b/src/main/java/ome/codecs/CodecException.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * Top-level reader and writer APIs
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/CodecOptions.java
+++ b/src/main/java/ome/codecs/CodecOptions.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * Top-level reader and writer APIs
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/CompressionType.java
+++ b/src/main/java/ome/codecs/CompressionType.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/HuffmanCodec.java
+++ b/src/main/java/ome/codecs/HuffmanCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/HuffmanCodecOptions.java
+++ b/src/main/java/ome/codecs/HuffmanCodecOptions.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/JPEG2000BoxType.java
+++ b/src/main/java/ome/codecs/JPEG2000BoxType.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/JPEG2000Codec.java
+++ b/src/main/java/ome/codecs/JPEG2000Codec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/JPEG2000CodecOptions.java
+++ b/src/main/java/ome/codecs/JPEG2000CodecOptions.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/JPEG2000SegmentMarker.java
+++ b/src/main/java/ome/codecs/JPEG2000SegmentMarker.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/JPEGCodec.java
+++ b/src/main/java/ome/codecs/JPEGCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/JPEGTileDecoder.java
+++ b/src/main/java/ome/codecs/JPEGTileDecoder.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/LZOCodec.java
+++ b/src/main/java/ome/codecs/LZOCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/LZWCodec.java
+++ b/src/main/java/ome/codecs/LZWCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/LosslessJPEGCodec.java
+++ b/src/main/java/ome/codecs/LosslessJPEGCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/LuraWaveCodec.java
+++ b/src/main/java/ome/codecs/LuraWaveCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/MJPBCodec.java
+++ b/src/main/java/ome/codecs/MJPBCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/MJPBCodecOptions.java
+++ b/src/main/java/ome/codecs/MJPBCodecOptions.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/MSRLECodec.java
+++ b/src/main/java/ome/codecs/MSRLECodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/MSVideoCodec.java
+++ b/src/main/java/ome/codecs/MSVideoCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/MissingLibraryException.java
+++ b/src/main/java/ome/codecs/MissingLibraryException.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * Top-level reader and writer APIs
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/NikonCodecOptions.java
+++ b/src/main/java/ome/codecs/NikonCodecOptions.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/PackbitsCodec.java
+++ b/src/main/java/ome/codecs/PackbitsCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/PassthroughCodec.java
+++ b/src/main/java/ome/codecs/PassthroughCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/QTRLECodec.java
+++ b/src/main/java/ome/codecs/QTRLECodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/RPZACodec.java
+++ b/src/main/java/ome/codecs/RPZACodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/UnsupportedCompressionException.java
+++ b/src/main/java/ome/codecs/UnsupportedCompressionException.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * Top-level reader and writer APIs
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/ZlibCodec.java
+++ b/src/main/java/ome/codecs/ZlibCodec.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/gui/AWTImageTools.java
+++ b/src/main/java/ome/codecs/gui/AWTImageTools.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/gui/SignedByteBuffer.java
+++ b/src/main/java/ome/codecs/gui/SignedByteBuffer.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/gui/SignedShortBuffer.java
+++ b/src/main/java/ome/codecs/gui/SignedShortBuffer.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/gui/TwoChannelColorSpace.java
+++ b/src/main/java/ome/codecs/gui/TwoChannelColorSpace.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/gui/UnsignedIntBuffer.java
+++ b/src/main/java/ome/codecs/gui/UnsignedIntBuffer.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/gui/UnsignedIntColorModel.java
+++ b/src/main/java/ome/codecs/gui/UnsignedIntColorModel.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/package.html
+++ b/src/main/java/ome/codecs/package.html
@@ -1,6 +1,6 @@
 <!--
   #%L
-  BSD implementations of Bio-Formats readers and writers
+  Image encoding and decoding routines.
   %%
   Copyright (C) 2005 - 2017 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/services/JAIIIOService.java
+++ b/src/main/java/ome/codecs/services/JAIIIOService.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/services/JAIIIOServiceImpl.java
+++ b/src/main/java/ome/codecs/services/JAIIIOServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/services/LuraWaveService.java
+++ b/src/main/java/ome/codecs/services/LuraWaveService.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/main/java/ome/codecs/services/LuraWaveServiceImpl.java
+++ b/src/main/java/ome/codecs/services/LuraWaveServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/test/java/ome/codecs/utests/JAIIIOServiceTest.java
+++ b/src/test/java/ome/codecs/utests/JAIIIOServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/test/java/ome/codecs/utests/LuraWaveServiceTest.java
+++ b/src/test/java/ome/codecs/utests/LuraWaveServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/test/java/ome/codecs/utests/MissingJAIIIOServiceTest.java
+++ b/src/test/java/ome/codecs/utests/MissingJAIIIOServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/test/java/ome/codecs/utests/MissingLuraWaveServiceTest.java
+++ b/src/test/java/ome/codecs/utests/MissingLuraWaveServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * BSD implementations of Bio-Formats readers and writers
+ * Image encoding and decoding routines.
  * %%
  * Copyright (C) 2005 - 2017 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison

--- a/src/test/java/ome/codecs/utests/testng-no-jai.xml
+++ b/src/test/java/ome/codecs/utests/testng-no-jai.xml
@@ -1,6 +1,6 @@
 <!--
   #%L
-  BSD implementations of Bio-Formats readers and writers
+  Image encoding and decoding routines.
   %%
   Copyright (C) 2005 - 2017 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison

--- a/src/test/java/ome/codecs/utests/testng-no-lurawave.xml
+++ b/src/test/java/ome/codecs/utests/testng-no-lurawave.xml
@@ -1,6 +1,6 @@
 <!--
   #%L
-  BSD implementations of Bio-Formats readers and writers
+  Image encoding and decoding routines.
   %%
   Copyright (C) 2005 - 2017 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison

--- a/src/test/java/ome/codecs/utests/testng.xml
+++ b/src/test/java/ome/codecs/utests/testng.xml
@@ -1,6 +1,6 @@
 <!--
   #%L
-  BSD implementations of Bio-Formats readers and writers
+  Image encoding and decoding routines.
   %%
   Copyright (C) 2005 - 2017 Open Microscopy Environment:
     - Board of Regents of the University of Wisconsin-Madison


### PR DESCRIPTION
Follow-up of https://github.com/ome/ome-codecs/pull/1#discussion_r124730867, this fixes the pom, README and license headers to use the correct description