### PR TITLE
JPEGTileDecoder: Implement AutoCloseable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.openmicroscopy</groupId>
   <artifactId>ome-codecs</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
 
   <name>OME Codecs</name>
   <description>Image encoding and decoding routines.</description>

--- a/src/main/java/ome/codecs/JPEGTileDecoder.java
+++ b/src/main/java/ome/codecs/JPEGTileDecoder.java
@@ -170,9 +170,7 @@ public class JPEGTileDecoder implements AutoCloseable {
     return consumer.getHeight();
   }
 
-  public void close()
-    throws Exception
-  {
+  public void close() {
     try {
       if (in != null) {
         in.close();

--- a/src/main/java/ome/codecs/JPEGTileDecoder.java
+++ b/src/main/java/ome/codecs/JPEGTileDecoder.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  */
-public class JPEGTileDecoder {
+public class JPEGTileDecoder implements AutoCloseable {
 
   // -- Constants --
 
@@ -170,7 +170,9 @@ public class JPEGTileDecoder {
     return consumer.getHeight();
   }
 
-  public void close() {
+  public void close()
+    throws Exception
+  {
     try {
       if (in != null) {
         in.close();


### PR DESCRIPTION
Add the `AutoCloseable` interface.  This requires throwing `Exception`, so is a breaking change.

Testing: Check travis is green.