### PR TITLE
MJPB: fix Huffman table handling for images with multiple components

### DIFF
--- a/src/main/java/ome/codecs/MJPBCodec.java
+++ b/src/main/java/ome/codecs/MJPBCodec.java
@@ -216,9 +216,10 @@ public class MJPBCodec extends BaseCodec {
       v.add(quant2 == null ? quant : quant2);
 
       v.add(new byte[] {(byte) 0xff, (byte) 0xc4});
-      length = 6;
+      length = 2;
       for (Table t : huffmanTables) {
         length += t.content.length;
+        length++;
       }
       v.add((byte) ((length >>> 8) & 0xff));
       v.add((byte) (length & 0xff));


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org/ome/ticket/4087

This definitely isn't an urgent/critical fix, more an excuse to close a very old ticket.

The easiest way to test is likely to switch a local build of Bio-Formats to use ```0.2.1-SNAPSHOT``` and compare the results of ```showinf``` on ```data_repo/curated/quicktime/mjpb/*.mov``` with and without this PR included in the snapshot build.  The PDF file in the same directory is a screenshot for verification.

I'm not completely clear on the expected workflow for reviewing PRs in this repo though, so happy to discuss.