### PR TITLE
build: Update maven plugin versions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,31 @@
+environment:
+  AV_PROJECTS: 'c:\projects'
+  AV_OME_M2: 'c:\projects\m2'
+  AV_OME_SOURCE: 'c:\projects\source'
+
+# Note that only Oracle JDK is provided.
+  matrix:
+    - java: 9
+    - java: 1.8
+    - java: 1.7
+
+cache:
+  - '%AV_OME_M2% -> appveyor.yml'
+  - '%AV_OME_PYTHON% -> appveyor.yml'
+
+os: 'Visual Studio 2015'
+clone_folder: '%AV_OME_SOURCE%'
+clone_depth: 5
+platform: x64
+
+init:
+  - git config --global core.autocrlf input
+  - refreshenv
+  - 'if [%java%] == [1.7] set "JAVA_HOME=C:\Program Files\Java\jdk1.7.0"'
+  - 'if [%java%] == [1.8] set "JAVA_HOME=C:\Program Files\Java\jdk1.8.0"'
+  - 'if [%java%] == [9] set "JAVA_HOME=C:\Program Files\Java\jdk9"'
+  - PATH=%JAVA_HOME%\bin;%PATH%
+  - 'set "MAVEN_OPTS=-Dmaven.repo.local=%AV_OME_M2%"'
+
+build_script:
+  - mvn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   - $HOME/.m2
 
 jdk:
+  - oraclejdk9
   - oraclejdk8
   - openjdk7
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
   </mailingLists>
 
   <prerequisites>
-    <maven>3.0</maven>
+    <maven>3.0.5</maven>
   </prerequisites>
 
   <scm>
@@ -146,7 +146,7 @@
       <plugin>
 	<groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.7.0</version>
         <!-- Require the Java 7 platform. -->
         <configuration>
           <source>1.7</source>
@@ -161,7 +161,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>1.9</version>
+        <version>1.14</version>
         <configuration>
           <licenseName>bsd_2</licenseName>
           <organizationName>Open Microscopy Environment:
@@ -187,7 +187,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.20.1</version>
         <configuration>
             <skip>true</skip>
         </configuration>
@@ -227,7 +227,7 @@
 
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.10.0</version>
       </plugin>
 
       <plugin>
@@ -237,7 +237,7 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.10</version>
+        <version>3.0.2</version>
       </plugin>
 
       <plugin>
@@ -283,7 +283,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <!-- NB: The same version declaration and configuration block also
              appears in the <reporting> section, and must be kept in sync. -->
-        <version>2.10.4</version>
+        <version>3.0.0</version>
         <configuration>
           <failOnError>false</failOnError>
           <links>
@@ -319,12 +319,12 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.2</version>
       </plugin>
 
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.7</version>
       </plugin>
 
       <!-- Create -sources.jar when building. -->
@@ -372,31 +372,12 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.5</version>
       </plugin>
     </plugins>
   </build>
 
   <profiles>
-    <profile>
-      <id>doclint-java8-disable</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
-            <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>release</id>
       <build>
@@ -405,7 +386,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.7</version>
+            <version>1.6.8</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
@@ -418,7 +399,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -440,7 +421,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.0.0</version>
         <configuration>
           <failOnError>false</failOnError>
           <links>


### PR DESCRIPTION
Same as https://github.com/ome/ome-common-java/pull/16 (see this PR for rationale and testing instructions).  Note ome-common and other dependencies are unchanged because it doesn't have a compile- or runtime-dependency upon the new version.