### PR TITLE
ZLIB: use ByteArrayHandle instead of ByteVector for decompressing

### DIFF
--- a/src/main/java/ome/codecs/ZlibCodec.java
+++ b/src/main/java/ome/codecs/ZlibCodec.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.util.zip.Deflater;
 import java.util.zip.InflaterInputStream;
 
+import loci.common.ByteArrayHandle;
 import loci.common.RandomAccessInputStream;
 import ome.codecs.CodecException;
 
@@ -73,15 +74,15 @@ public class ZlibCodec extends BaseCodec {
     throws CodecException, IOException
   {
     InflaterInputStream i = new InflaterInputStream(in);
-    ByteVector bytes = new ByteVector();
+    ByteArrayHandle bytes = new ByteArrayHandle((int) in.length());
     byte[] buf = new byte[8192];
     int r = 0;
     // read until eof reached
     try {
-      while ((r = i.read(buf, 0, buf.length)) > 0) bytes.add(buf, 0, r);
+      while ((r = i.read(buf, 0, buf.length)) > 0) bytes.write(buf, 0, r);
     }
     catch (EOFException e) { }
-    return bytes.toByteArray();
+    return bytes.getBytes();
   }
 
 }

--- a/src/main/java/ome/codecs/ZlibCodec.java
+++ b/src/main/java/ome/codecs/ZlibCodec.java
@@ -34,6 +34,7 @@ package ome.codecs;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.zip.Deflater;
 import java.util.zip.InflaterInputStream;
 
@@ -82,7 +83,11 @@ public class ZlibCodec extends BaseCodec {
       while ((r = i.read(buf, 0, buf.length)) > 0) bytes.write(buf, 0, r);
     }
     catch (EOFException e) { }
-    return bytes.getBytes();
+    ByteBuffer decompressed = bytes.getByteBuffer();
+    byte[] rtn = new byte[decompressed.position()];
+    decompressed.position(0);
+    decompressed.get(rtn);
+    return rtn;
   }
 
 }

--- a/src/main/java/ome/codecs/ZlibCodec.java
+++ b/src/main/java/ome/codecs/ZlibCodec.java
@@ -75,7 +75,7 @@ public class ZlibCodec extends BaseCodec {
     throws CodecException, IOException
   {
     InflaterInputStream i = new InflaterInputStream(in);
-    ByteArrayHandle bytes = new ByteArrayHandle((int) in.length());
+    ByteArrayHandle bytes = new ByteArrayHandle();
     byte[] buf = new byte[8192];
     int r = 0;
     // read until eof reached

--- a/src/test/java/ome/codecs/RoundtripTest.java
+++ b/src/test/java/ome/codecs/RoundtripTest.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * Image encoding and decoding routines.
+ * %%
+ * Copyright (C) 2018 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package ome.codecs;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ *
+ */
+public class RoundtripTest {
+
+  private static byte[] data = new byte[256];
+
+  @BeforeMethod
+  public void setUp() {
+    for (int i=0; i<data.length; i++) {
+      data[i] = (byte) i;
+    }
+  }
+
+  @Test
+  public void testZLIB() throws CodecException, IOException {
+    ZlibCodec codec = new ZlibCodec();
+    byte[] compressed = codec.compress(data, null);
+    assertNotNull(compressed);
+    byte[] decompressed = codec.decompress(compressed);
+    assertTrue(Arrays.equals(decompressed, data));
+  }
+}


### PR DESCRIPTION
Partial backport from a private PR.

```ByteVector``` doesn't have any functionality not present in ```ByteArrayHandle```.  This commit lets us to measure the impact of switching to ```ByteArrayHandle``` in an isolated case, which would allow for an informed decision about whether it makes sense to deprecate ```ByteVector```.

With a *.C01 file from ```data_repo/curated/cellomics/``` (e.g. anything in the ```omar``` subdirectory) and test code similar to:

```
import loci.common.RandomAccessInputStream;
import ome.codecs.ZlibCodec;

public class Test {
  public static void main(String[] args) throws Exception {
    String file = args[0];
    int count = Integer.parseInt(args[1]);
    ZlibCodec codec = new ZlibCodec();
    long decompressTime = 0;
    for (int i=0; i<count; i++) {
      RandomAccessInputStream s = new RandomAccessInputStream(file);
      s.seek(4);
      long t0 = System.currentTimeMillis();
      codec.decompress(s, null);
      long t1 = System.currentTimeMillis();
      s.close();
      decompressTime += (t1 - t0);
    }
    /* debug */ System.out.println("decompress time: " + decompressTime + "ms (avg: " + ((double) decompressTime / count) + "ms)");
  }
}
```

there shouldn't be a statistically significant difference in performance with or without this PR.  If performance is noticeably worse or there are other reasons to continue using ```ByteVector```, this can be closed outright.