### PR TITLE
JPEG: reduce decompression time for 8-bit RGB images

### DIFF
--- a/src/main/java/ome/codecs/JPEGCodec.java
+++ b/src/main/java/ome/codecs/JPEGCodec.java
@@ -124,7 +124,9 @@ public class JPEGCodec extends BaseCodec {
 
     int nPixels = b.getWidth() * b.getHeight();
     WritableRaster r = (WritableRaster) b.getRaster();
-    if (!options.ycbcr && r.getDataBuffer() instanceof DataBufferByte) {
+    if (!options.ycbcr && r.getDataBuffer() instanceof DataBufferByte &&
+      b.getType() == BufferedImage.TYPE_BYTE_GRAY)
+    {
       DataBufferByte bb = (DataBufferByte) r.getDataBuffer();
 
       if (bb.getNumBanks() == 1) {


### PR DESCRIPTION
Related to https://github.com/openmicroscopy/bioformats/pull/3336, backported from a private PR.

Increasing the buffer size for ```BufferedInputStream``` shows a modest improvement for large images (~2500x1600).  The special case that checks if the type and dimensions of the buffer backing the ```BufferedImage``` will reduce the amount of array allocation and copying needed for RGB images that are requested in interleaved order.

This shouldn't have any impact on the actual byte array that is returned by ```decompress(...)```.  I wouldn't expect to see much of a performance difference for small JPEG files, but for most larger files and TIFF-based formats that use JPEG tiles there should be a noticeable improvement.