### PR TITLE
Allow the Huffman decoding tree to go all the way down to the 16-bit depth required by the standard

### DIFF
--- a/src/main/java/ome/codecs/HuffmanCodec.java
+++ b/src/main/java/ome/codecs/HuffmanCodec.java
@@ -189,7 +189,7 @@ public class HuffmanCodec extends BaseCodec {
         i += source[start + next++] & 0xff;
       }
 
-      if (level < next && next < LEAVES_OFFSET) {
+      if (level < next && next <= LEAVES_OFFSET) {
         dest.branch[0] = createDecoder(source, start, level + 1);
         dest.branch[1] = createDecoder(source, start, level + 1);
       }


### PR DESCRIPTION
I found some medical images in the wild that the ome-codecs library failed to decode properly. The resulting output values were completely wrong.
I found that these image files had huffman tables that included 16-bit codes. Because of that I found that the Huffman codec code stopped creating its decoder tree at the 15-bit level.

If you look at the while loop immediately above my change you can see that it is legal for "next" to equal LEAVES_OFFSET because it can still increment "next" when it equals (LEAVES_OFFSET-1) and it won't know it's done until i is >= leafCounter. All of that code is correct.

Furthermore, the root node of the decoder tree is purely a head (doesn't store any leaves). So, bit 1 is stored at level 1, bit 2 at level 2, etc. So in order to store a bit 16, next has to be allowed to go all the way to 16 but the old code limited it to 15.

The problem images I have are medical DICOM files that have been anonymized. I can provide one if absolutely necessary. However, you can see that the code change can't change the behavior for any files with (sane) Huffman tables whose largest codes have fewer than 16 bits. This change merely makes it work properly for more files.