### PR TITLE
Better compliance with the LJPEG standard

### DIFF
--- a/src/main/java/ome/codecs/LosslessJPEGCodec.java
+++ b/src/main/java/ome/codecs/LosslessJPEGCodec.java
@@ -192,7 +192,7 @@ public class LosslessJPEGCodec extends BaseCodec {
             if (huffmanTables != null) {
               v = huffman.getSample(bb, huffmanOptions);
               if (nextSample == 0) {
-                v += (int) Math.pow(2, bitsPerSample - 1);
+                v += (int) Math.pow(2, bitsPerSample - pointTransform - 1);
               }
             }
             else {
@@ -215,11 +215,11 @@ public class LosslessJPEGCodec extends BaseCodec {
               componentOffset;
 
             int sampleA = indexA < 0 ? 0 :
-              DataTools.bytesToInt(buf, indexA, bytesPerSample, false);
+              DataTools.bytesToInt(buf, indexA, bytesPerSample, false) >> pointTransform;
             int sampleB = indexB < 0 ? 0 :
-              DataTools.bytesToInt(buf, indexB, bytesPerSample, false);
+              DataTools.bytesToInt(buf, indexB, bytesPerSample, false) >> pointTransform;
             int sampleC = indexC < 0 ? 0 :
-              DataTools.bytesToInt(buf, indexC, bytesPerSample, false);
+              DataTools.bytesToInt(buf, indexC, bytesPerSample, false) >> pointTransform;
 
             if (nextSample > 0) {
               int pred = 0;
@@ -237,13 +237,13 @@ public class LosslessJPEGCodec extends BaseCodec {
                   pred = sampleA + sampleB + sampleC;
                   break;
                 case 5:
-                  pred = sampleA + ((sampleB - sampleC) / 2);
+                  pred = sampleA + ((sampleB - sampleC) >> 1);
                   break;
                 case 6:
-                  pred = sampleB + ((sampleA - sampleC) / 2);
+                  pred = sampleB + ((sampleA - sampleC) >> 1);
                   break;
                 case 7:
-                  pred = (sampleA + sampleB) / 2;
+                  pred = (sampleA + sampleB) >> 1;
                   break;
               }
               v += pred;
@@ -251,7 +251,7 @@ public class LosslessJPEGCodec extends BaseCodec {
 
             int offset = componentOffset + nextSample;
 
-            DataTools.unpackBytes(v, buf, offset, bytesPerSample, false);
+            DataTools.unpackBytes(v << pointTransform, buf, offset, bytesPerSample, false);
           }
           nextSample += bytesPerSample;
         }


### PR DESCRIPTION
While investigating the Huffman table problem I noticed a couple of things wrong and missing.
The code read in the "pointTransform" value into a variable but never used it. Based on the standard and other code as reference, I added code to properly handle the case where the point transform is non-zero. That feature may almost never be used, but now the codec is able to handle such files.

I also noticed that the existing code used "/ 2" for a couple of the predictor types. I saw that the standard explicitly states that an arithmetic right shift of 1 bit should be used for the differential types since shifting signed values can produce different results than dividing by 2. Specifically, -1 ==> -1 rather than -1 ==> 0. Though it doesn't matter, I also changed the unsigned case to a shift for consistency.

I don't have any test files to fully test either change but did verify that they don't break decoding of my Huffman test images. That makes sense, since pointTransform is zero and they don't use any of those three predictor types. Our internal version of the library now has these changes.
I leave it up to you whether you want to incorporate these changes. They should provide a wider range of image file compatibility, but I don't know if any such images actually exist. At least one other library (thorfdbg/libjpeg) has code similar to this - I was using it as a reference after I noticed these mistakes.