### PR TITLE
Fix decompression in Base64Codec

### DIFF
--- a/src/main/java/ome/codecs/Base64Codec.java
+++ b/src/main/java/ome/codecs/Base64Codec.java
@@ -177,7 +177,6 @@ public class Base64Codec extends BaseCodec {
       }
 
       decodedData.add((byte) (b1 << 2 | b2 >> 4));
-      if (p >= nRead && in.getFilePointer() >= in.length()) break;
       if (marker0 != PAD && marker1 != PAD) {
         b3 = base64Alphabet[marker0];
         b4 = base64Alphabet[marker1];
@@ -185,16 +184,12 @@ public class Base64Codec extends BaseCodec {
         decodedData.add((byte) (((b2 & 0xf) << 4) | ((b3 >> 2) & 0xf)));
         decodedData.add((byte) (b3 << 6 | b4));
       }
-      else if (marker0 == PAD) {
-        decodedData.add((byte) 0);
-        decodedData.add((byte) 0);
-      }
-      else if (marker1 == PAD) {
+      else if (marker0 != PAD && marker1 == PAD) {
         b3 = base64Alphabet[marker0];
 
         decodedData.add((byte) (((b2 & 0xf) << 4) | ((b3 >> 2) & 0xf)));
-        decodedData.add((byte) 0);
       }
+      if (p >= nRead && in.getFilePointer() >= in.length()) break;
       b1 = base64Alphabet[block[p++]];
       b2 = base64Alphabet[block[p++]];
     }

--- a/src/test/java/ome/codecs/Base64CodecTest.java
+++ b/src/test/java/ome/codecs/Base64CodecTest.java
@@ -1,0 +1,73 @@
+/*
+ * #%L
+ * Image encoding and decoding routines.
+ * %%
+ * Copyright (C) 2005 - 2017 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package ome.codecs;
+
+import java.util.Random;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class Base64CodecTest {
+  Base64Codec codec = new Base64Codec();
+
+  @Test
+  public void testRoundtripShortSequence() throws Exception {
+    byte[] in = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    roundtrip(in);
+  }
+
+  @Test
+  public void testRoundtripCheckerboard() throws Exception {
+    byte[] in = {0, (byte) 255, 0, (byte) 255,
+                 (byte) 255, 0, (byte) 255, 0,
+                 0, (byte) 255, 0, (byte) 255,
+                 (byte) 255, 0, (byte) 255, 0};
+    roundtrip(in);
+  }
+
+  @Test
+  public void testCompressUncompressParity() throws Exception {
+    for (int j = 0; j < 100; j++) {
+      byte[] in = new byte[50000];
+      new Random().nextBytes(in);
+      roundtrip(in);
+    }
+  }
+
+  private void roundtrip(byte[] in) throws CodecException {
+    byte[] encoded = codec.compress(in, null);
+    byte[] decoded = codec.decompress(encoded, null);
+    assertEquals(in, decoded);
+  }
+}


### PR DESCRIPTION
Adds round-trip tests for ```Base64Codec``` (similar to ```LZWCodec```), and fixes the decompression implementation so that the tests pass.  ```OMEXMLReader``` uses Guava to do base64 decoding (https://github.com/ome/bioformats/blob/22610fb7a3437a6a47b2ab792ecef0995c90f985/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java#L165), so this functionality probably isn't being used much if at all.

If/when this repository can have the source and target versions updated to 1.8, it's probably worth either completely deprecating ```Base64Codec``` or having it just wrap https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html.