### PR TITLE
Use in-memory cache with JPEGCodec

### DIFF
--- a/src/main/java/ome/codecs/JPEGCodec.java
+++ b/src/main/java/ome/codecs/JPEGCodec.java
@@ -80,7 +80,9 @@ public class JPEGCodec extends BaseCodec {
       throw new CodecException("> 8 bit data cannot be compressed with JPEG.");
     }
 
-    ByteArrayOutputStream out = new ByteArrayOutputStream(Math.max(1024, data.length / 4));
+    int maxByteArrayLength = Integer.MAX_VALUE / 8;
+    ByteArrayOutputStream out = new ByteArrayOutputStream(
+            Math.min(maxByteArrayLength, Math.max(1024, data.length / 4)));
     BufferedImage img = AWTImageTools.makeImage(data, options.width,
       options.height, options.channels, options.interleaved,
       options.bitsPerSample / 8, false, options.littleEndian, options.signed);
@@ -128,6 +130,7 @@ public class JPEGCodec extends BaseCodec {
     	  throw new NullPointerException("ImageIO returned null when reading JPEG stream");
     }
     catch (IOException exc) {
+        in.seek(fp);
         return new LosslessJPEGCodec().decompress(in, options);
     }
 

--- a/src/main/java/ome/codecs/JPEGCodec.java
+++ b/src/main/java/ome/codecs/JPEGCodec.java
@@ -42,10 +42,15 @@ import java.io.EOFException;
 import java.io.IOException;
 
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageInputStream;
+import javax.imageio.stream.ImageOutputStream;
+import javax.imageio.stream.MemoryCacheImageInputStream;
+import javax.imageio.stream.MemoryCacheImageOutputStream;
 
 import loci.common.DataTools;
 import loci.common.RandomAccessInputStream;
-import ome.codecs.CodecException;
 import ome.codecs.gui.AWTImageTools;
 
 /**
@@ -82,7 +87,12 @@ public class JPEGCodec extends BaseCodec {
       options.bitsPerSample / 8, false, options.littleEndian, options.signed);
 
     try {
-      ImageIO.write(img, "jpeg", out);
+    	ImageOutputStream stream = new MemoryCacheImageOutputStream(out);
+        ImageWriter writer = ImageIO.getImageWritersByFormatName("jpeg").next();
+        writer.setOutput(stream);
+        writer.write(img);
+        
+//      ImageIO.write(img, "jpeg", out);
     }
     catch (IOException e) {
       throw new CodecException("Could not write JPEG data", e);
@@ -112,7 +122,11 @@ public class JPEGCodec extends BaseCodec {
         in.seek(fp);
       }
 
-      b = ImageIO.read(new BufferedInputStream(new DataInputStream(in), 81920));
+      ImageInputStream stream = new MemoryCacheImageInputStream(new BufferedInputStream(new DataInputStream(in), 81920));
+      ImageReader reader = ImageIO.getImageReadersByFormatName("jpeg").next();
+      reader.setInput(stream, true, true);
+      b = reader.read(0);
+//      b = ImageIO.read(new BufferedInputStream(new DataInputStream(in), 81920));
     }
     catch (IOException exc) {
       // probably a lossless JPEG; delegate to LosslessJPEGCodec

--- a/src/main/java/ome/codecs/JPEGCodec.java
+++ b/src/main/java/ome/codecs/JPEGCodec.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.util.Iterator;
 
 import javax.imageio.ImageIO;
-import javax.imageio.ImageReader;
 import javax.imageio.ImageWriter;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
@@ -124,22 +123,11 @@ public class JPEGCodec extends BaseCodec {
       }
 
       ImageInputStream stream = new MemoryCacheImageInputStream(new BufferedInputStream(in, 81920));
-      Iterator<ImageReader> iterator = ImageIO.getImageReadersByFormatName("jpeg");
-      while (iterator.hasNext()) {
-    	  ImageReader reader = iterator.next();
-          reader.setInput(stream, true, true);
-          b = reader.read(0);
-          if (b == null)
-        	  in.seek(fp);
-          else
-        	  break;
-      }
+      b = ImageIO.read(stream);
+      if (b == null)
+    	  throw new NullPointerException("ImageIO returned null when reading JPEG stream");
     }
     catch (IOException exc) {
-      // probably a lossless JPEG; delegate to LosslessJPEGCodec
-    }
-    if (b == null) {
-        in.seek(fp);
         return new LosslessJPEGCodec().decompress(in, options);
     }
 


### PR DESCRIPTION
This PR aims to improve JPEG compression/decompression performance, particularly with TIFF images.

The original JPEGCodec passes an `InputStream` or `OutputStream` to ImageIO.
Strangely, ImageIO in OpenJDK seems to then create a temporary file from this (regardless of whether caching is requested or not) before using `FileImageInputStream`, which can be a significant performance issue e.g. with whole slide images.

This can be avoided by explicitly creating a `MemoryCacheImageInputStream` or the corresponding output stream.

The PR contains two other minor modifications that helped further reduce runtime in my tests:
* set an initial capacity for the `ByteArrayOutputStream`
* rearrange the code when creating an interleaved pixel array

Overall, I saw conversion time for a JPEG-compressed whole slide image to a JPEG-compressed ome.tiff (e.g. CMU-1.svs) reduce by up to 50%, by speeding up both reading and writing.

---

**Risks:** There is a slightly enigmatic warning [in the ImageIO docs](https://docs.oracle.com/javase/7/docs/api/index.html?javax/imageio/ImageIO.html)

> In general, it is preferable to use a `FileCacheImageInputStream` when reading from a regular `InputStream`. This class is provided for cases where it is not possible to create a writable temporary file.

However, ImageIO's TIFF reader [uses `MemoryCacheImageInputStream`](https://github.com/openjdk/jdk/blob/ec7cb6d5d305003429b51384ed72973767c70124/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFJPEGDecompressor.java#L126).