### PR TITLE
Replace one-jai with jai-imageio-jpeg2000

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,9 +93,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.openmicroscopy</groupId>
-      <artifactId>ome-jai</artifactId>
-      <version>${ome-jai.version}</version>
+      <groupId>com.github.jai-imageio</groupId>
+      <artifactId>jai-imageio-jpeg2000</artifactId>
+      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.openmicroscopy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
 
   <properties>
     <ome-common.version>6.0.9</ome-common.version>
-    <ome-jai.version>0.1.3</ome-jai.version>
     <ome-stubs.version>5.3.2</ome-stubs.version>
     <lwf-stubs.version>${ome-stubs.version}</lwf-stubs.version>
 
@@ -222,7 +221,7 @@
                 <include>%regex[.*Missing.*Test.*]</include>
               </includes>
               <classpathDependencyExcludes>
-                 <classpathDependencyExcludes>org.openmicroscopy:ome-jai</classpathDependencyExcludes>
+                 <classpathDependencyExcludes>com.github.jai-imageio:jai-imageio-jpeg2000</classpathDependencyExcludes>
                  <classpathDependencyExcludes>org.openmicroscopy:lwf-stubs</classpathDependencyExcludes>
               </classpathDependencyExcludes>
             </configuration>

--- a/src/main/java/ome/codecs/services/JAIIIOServiceImpl.java
+++ b/src/main/java/ome/codecs/services/JAIIIOServiceImpl.java
@@ -47,16 +47,18 @@ import javax.imageio.spi.IIORegistry;
 import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.stream.MemoryCacheImageInputStream;
 
+import com.github.jaiimageio.jpeg2000.J2KImageReadParam;
+import com.github.jaiimageio.jpeg2000.J2KImageWriteParam;
+import com.github.jaiimageio.jpeg2000.impl.J2KImageReader;
+import com.github.jaiimageio.jpeg2000.impl.J2KImageReaderSpi;
+import com.github.jaiimageio.jpeg2000.impl.J2KImageWriter;
+import com.github.jaiimageio.jpeg2000.impl.J2KImageWriterSpi;
+
 import loci.common.services.AbstractService;
 import loci.common.services.ServiceException;
 import ome.codecs.JPEG2000CodecOptions;
 
-import com.sun.media.imageio.plugins.jpeg2000.J2KImageReadParam;
-import com.sun.media.imageio.plugins.jpeg2000.J2KImageWriteParam;
-import com.sun.media.imageioimpl.plugins.jpeg2000.J2KImageReader;
-import com.sun.media.imageioimpl.plugins.jpeg2000.J2KImageReaderSpi;
-import com.sun.media.imageioimpl.plugins.jpeg2000.J2KImageWriter;
-import com.sun.media.imageioimpl.plugins.jpeg2000.J2KImageWriterSpi;
+
 
 /**
  * Implementation of JAIIIOService for reading and writing JPEG-2000 data.


### PR DESCRIPTION
This is a follow up to the thread https://forum.image.sc/t/status-of-jai-imageio-forks/69438
Replaces the deprecated ome-jai with https://github.com/jai-imageio/jai-imageio-jpeg2000

Opening this PR for further testing