### PR TITLE
Update aircompressor to 0.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
-      <version>0.18</version>
+      <version>0.21</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
See https://github.com/ome/bioformats/pull/3815#issuecomment-1296805754, https://github.com/airlift/aircompressor/issues/125.

I could locally reproduce exceptions from the test failures in https://github.com/ome/bioformats/pull/3815#issuecomment-1296805754, using just `showinf`. This change fixes the problem locally, so hopefully causes the tests to pass again.