### PR TITLE
Setting jpeg quality in JPEGCodec

### DIFF
--- a/src/main/java/ome/codecs/JPEGCodec.java
+++ b/src/main/java/ome/codecs/JPEGCodec.java
@@ -97,7 +97,6 @@ public class JPEGCodec extends BaseCodec {
 
     try {
       //::phaub 09.02.23   (Adjustable jpeg quality)
-      	
       // How to use:
       // Set jpegquality using CodecOptions in the calling object (e.g. QuPath using OMEPyramidWriter()):
       //   CodecOptions options = new CodecOptions();
@@ -112,7 +111,7 @@ public class JPEGCodec extends BaseCodec {
     	
       ImageWriter jpgWriter = ImageIO.getImageWritersByFormatName("jpg").next();
       if (jpgWriter == null) {
-          return null;
+        return null;
       }
       ImageWriteParam jpgWriteParam = jpgWriter.getDefaultWriteParam();
       jpgWriteParam.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
@@ -121,16 +120,16 @@ public class JPEGCodec extends BaseCodec {
       ImageOutputStream stream = new MemoryCacheImageOutputStream(out);
       try {
         Iterator<ImageWriter> iterator = ImageIO.getImageWritersByFormatName("jpeg");
-    	  if (iterator.hasNext()) {
-	        ImageWriter writer = iterator.next();
-	        writer.setOutput(stream);
+    	if (iterator.hasNext()) {
+	  ImageWriter writer = iterator.next();
+	  writer.setOutput(stream);
           IIOImage outputImage = new IIOImage(img, null, null);
-	        writer.write(null, outputImage, jpgWriteParam);
+	  writer.write(null, outputImage, jpgWriteParam);
         }
       } finally {
-          jpgWriter.dispose();
-          stream.flush(); 	      
-          stream.close();
+        jpgWriter.dispose();
+        stream.flush(); 	      
+        stream.close();
       }          
     }
     catch (IOException e) {

--- a/src/main/java/ome/codecs/JPEGCodec.java
+++ b/src/main/java/ome/codecs/JPEGCodec.java
@@ -103,9 +103,9 @@ public class JPEGCodec extends BaseCodec {
       String OME_JPEGQUALITY = "ome.codec.jpegquality";
     	  
       double jpegquality = 0.75;
-      String sJPEGQuality = System.getProperty(OME_JPEGQUALITY, null);
-      if (sJPEGQuality != null)
-          jpegquality = Double.parseDouble(sJPEGQuality);
+      if (options.quality > 0) {
+        jpegquality = options.quality;
+      }
       jpegquality = Math.max(0.25, Math.min(1.0, jpegquality));
     	
       ImageWriter jpgWriter = ImageIO.getImageWritersByFormatName("jpg").next();


### PR DESCRIPTION
As a simple way to make the jpeg quality property settable, e.g. for use in QuPath, the approach of this PR uses System.setProperty() and System.getProperty to support adjustable jpeg quality while avoiding passing the 'jpegquality' value from QuPath through the entire class hierarchy from QuPath to Bioformats to ome.codecs.

Related to:
https://github.com/ome/bioformats/issues/3370