### PR TITLE
Disable chroma subsampling in JPEGCodec

### DIFF
--- a/src/main/java/ome/codecs/CodecOptions.java
+++ b/src/main/java/ome/codecs/CodecOptions.java
@@ -116,6 +116,11 @@ public class CodecOptions {
    * Whether or not the decompressed data will be stored as YCbCr.
    */
   public boolean ycbcr;
+  
+  /**
+   * Whether or not use chroma subsampling.
+   */
+  public boolean disableChromaSubsampling;
 
   // -- Constructors --
 

--- a/src/main/java/ome/codecs/JPEGCodec.java
+++ b/src/main/java/ome/codecs/JPEGCodec.java
@@ -117,7 +117,7 @@ public class JPEGCodec extends BaseCodec {
       //   CodecOptions options = new CodecOptions();
       //   options.disableChromaSubsampling = true;
       //   writer.setCodecOptions(options)
-      boolean disableChromaSubsampling = jpegquality>=90; 
+      boolean disableChromaSubsampling = jpegquality>=0.9; 
       if (options.disableChromaSubsampling) {
         disableChromaSubsampling = options.disableChromaSubsampling;
       }

--- a/src/main/java/ome/codecs/JPEGCodec.java
+++ b/src/main/java/ome/codecs/JPEGCodec.java
@@ -52,11 +52,9 @@ import loci.common.DataTools;
 import loci.common.RandomAccessInputStream;
 import ome.codecs.gui.AWTImageTools;
 
-//::phaub 09.02.23
 import javax.imageio.IIOImage;
 import javax.imageio.ImageWriteParam;
 
-//::phaub 29.06.23
 import javax.imageio.ImageTypeSpecifier;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -100,7 +98,7 @@ public class JPEGCodec extends BaseCodec {
       options.bitsPerSample / 8, false, options.littleEndian, options.signed);
 
     try {
-      //::phaub 09.02.23   (Adjustable jpeg quality)
+      // Adjustable jpeg quality
       // How to use:
       // Set jpegquality using CodecOptions in the calling object (e.g. QuPath using OMEPyramidWriter()):
       //   CodecOptions options = new CodecOptions();
@@ -113,7 +111,7 @@ public class JPEGCodec extends BaseCodec {
       }
       jpegquality = Math.max(0.25, Math.min(1.0, jpegquality));
 	    
-      //::phaub 29.06.23   (Disable chroma subsampling)
+      // Disable chroma subsampling
       // How to use:
       // Set disableChromaSubsampling using CodecOptions in the calling object (e.g. QuPath using OMEPyramidWriter()):
       //   CodecOptions options = new CodecOptions();
@@ -168,8 +166,7 @@ public class JPEGCodec extends BaseCodec {
     throws CodecException {
     // Disable JPEG chroma subsampling
     // http://svn.apache.org/repos/asf/shindig/trunk/java/gadgets/src/main/java/org/apache/shindig/gadgets/rewrite/image/BaseOptimizer.java
-    // http://svn.apache.org/repos/asf/shindig/trunk/java/gadgets/src/main/java/org/apache/shindig/gadgets/rewrite/image/JpegImageUtils.java
-    // Peter Haub, June. 2023
+    // http://svn.apache.org/repos/asf/shindig/trunk/java/gadgets/src/main/java/org/apache/shindig/gadgets/rewrite/image/JpegImageUtils.java  
     try {
       IIOMetadata metadata = jpgWriter.getDefaultImageMetadata(new ImageTypeSpecifier(img.getColorModel(), img.getSampleModel()), jpgWriteParam);
       Node rootNode = metadata!=null ? metadata.getAsTree("javax_imageio_jpeg_image_1.0") : null;


### PR DESCRIPTION
Follow up to PR https://github.com/ome/ome-codecs/pull/26
 
see https://github.com/ome/ome-codecs/pull/26#issuecomment-1456675017 :

There is another option that has a decisive influence on the Jpeg image quality: '**Chroma Subsampling**'.
Especially with biological/microscopic images in RGB format (transmitted light or fluorescence) chroma subsampling leads to intolerable image errors.
Chroma subsampling should therefore - in my view - be deactivatable in libraries like BioFormats.

Unfortunately, access to the 'Chroma Sampling' property is not configurable via the 'ImageWriteParam' (like e.g. the JpegQuality).
Instead, it can be accessed via the 'IIOMetadata'.

Unfortunately, so far have not been able to find a direct and simple description.
But it seems to exist in some form in the "JPEG Metadata Format Specification and Usage Notes".

In ImageJ, access to the 'Chroma Sampling' property is already integrated.
see https://imagej.nih.gov/ij/notes.html
_1.52s 10 December 2019
    Thanks to Peter Haub, chroma subsampling is disabled when saving in JPEG format if the Quality setting (Edit>Options>Input/Output) is 90 or higher, resulting in higher quality images but larger file sizes._

For example, chroma subsampling can be disabled with the following macro command:
JpegWriter.disableChromaSubsampling(true);
By default, 'Chroma Sampling' is disabled in ImageJ when JpegQuality >= 90.

My source at that time was Apache/Shindig.
See:
https://github.com/imagej/ImageJ/blob/d82104f1c55290af56d5afc29004cf8298055067/ij/plugin/JpegWriter.java#L86
_// Disable JPEG chroma subsampling
// http://svn.apache.org/repos/asf/shindig/trunk/java/gadgets/src/main/java/org/apache/shindig/gadgets/rewrite/image/BaseOptimizer.java
// http://svn.apache.org/repos/asf/shindig/trunk/java/gadgets/src/main/java/org/apache/shindig/gadgets/rewrite/image/JpegImageUtils.java_

There is a test script from Wayne here https://imagej.nih.gov/ij/macros/js/JpegQualityTests.js .
It can be called in the ImageJ menu under:  Help>Examples>Java Scripts> JPEG Quality Plot

I think it would be worth and important to have the 'Chroma Sampling' property in mind, especially with the current code changes to support variable Jpeg quality.

Unfortunately I lack the overview of ome-codecs to elaborate this hint more concretely.

Here are some further and interesting links:
_https://stackoverflow.com/questions/14149739/disable-java-imageio-chroma-subsampling
https://stackoverflow.com/questions/72581932/why-is-the-color-of-my-image-changed-after-writing-it-as-a-jpg-file
https://github.com/libvips/libvips/issues/538
http://poynton.ca/PDFs/Chroma_subsampling_notation.pdf_
