### PR TITLE
Use Maven profiles to handle different versions of TestNG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@
       <version>${ome-common.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>${testng.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
       <version>0.21</version>
@@ -412,28 +418,18 @@
       <activation>
         <jdk>(,11)</jdk>
       </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.testng</groupId>
-          <artifactId>testng</artifactId>
-          <version>7.5</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
+      <properties>
+        <testng.version>7.5</testng.version>
+      </properties>
     </profile>
     <profile>
       <id>jdk11+</id>
       <activation>
         <jdk>[11,)</jdk>
       </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.testng</groupId>
-          <artifactId>testng</artifactId>
-          <version>7.9.0</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
+      <properties>
+        <testng.version>7.9.0</testng.version>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -103,12 +103,6 @@
       <version>${ome-common.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>6.8</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
       <version>0.21</version>
@@ -412,6 +406,34 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>jdk8-only</id>
+      <activation>
+        <jdk>(,11)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>7.5</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>jdk11+</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>7.9.0</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Superseded #24 - see also https://github.com/ome/ome-common-java/pull/88

For JDK8, bump org.testng:testng to the last supported release for this version i.e. 7.5
For JDK11+, bump org.testng:testng to the latest release 7.9.0